### PR TITLE
axios interceptor

### DIFF
--- a/ban-importer/src/ban-fetcher.js
+++ b/ban-importer/src/ban-fetcher.js
@@ -1,12 +1,19 @@
-import axios from 'axios';
-import querystring from 'querystring';
+import { Logger, classifyBanReason } from 'scbl-lib/utils';
 
+import axios from 'axios';
 import { battlemetrics } from 'scbl-lib/apis';
-import { classifyBanReason, Logger } from 'scbl-lib/utils';
+import querystring from 'querystring';
 
 export default class BanFetcher {
   constructor(storeBanFunc) {
     this.storeBanFunc = storeBanFunc;
+
+    axios.interceptors.response.use((response) => {
+      return response;
+    }, (error) => {
+      // Any status codes that falls outside the range of 2xx cause this function to trigger
+      return Promise.reject(error.message);
+    });
   }
 
   async fetchBanList(banList) {

--- a/client/src/utils/http-client.js
+++ b/client/src/utils/http-client.js
@@ -1,10 +1,16 @@
-import axios from 'axios';
-
 import auth from './auth';
+import axios from 'axios';
 
 class HTTPClient {
   constructor() {
     this.axios = axios.create();
+
+    this.axios.interceptors.response.use((response) => {
+      return response;
+    }, (error) => {
+      // Any status codes that falls outside the range of 2xx cause this function to trigger
+      return Promise.reject(error.message);
+    });
   }
 
   get = (uri) => this.axios.get(uri, { headers: { Authorization: 'JWT ' + auth.jwtToken } });


### PR DESCRIPTION
Adds interceptor as WASP added for axios to `BanFetcher` in the ban-importer project and  `HTTPClient` in the client project.

This currently returns the rejected promise with the error message.  If we need to return `false` or different let me know. 

Also, my plugins reorder and organizes imports and those are changed here as well.