### PR TITLE
Updated kick message for export lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn.lock
 # IDEs
 .idea/
 .vs/
+.vscode/

--- a/scbl-lib/db/models/export-ban.js
+++ b/scbl-lib/db/models/export-ban.js
@@ -34,7 +34,7 @@ class ExportBan extends Sequelize.Model {
             ],
             nativeEnabled: null,
             note: null,
-            reason: `Appeal via communitybanlist.com/`
+            reason: `Kicked via communitybanlist.com/banned`
           },
           relationships: {
             organization: {


### PR DESCRIPTION
Updated kick message for update ban lists to reflect that appeals should not be requested through community ban list itself, but rather through partner platforms.